### PR TITLE
Push everything to docker container except of backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+SA_PASSWORD=myPassword1234

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,12 @@ services:
       - "3000:3000"
     command: npm start
 
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    container_name: mssql
+    ports:
+      - "1433:1433"
+    env_file:
+      - .env
+    environment:
+      SA_PASSWORD: ${SA_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  frontend:
+    build: ./frontend
+    container_name: frontend
+    ports:
+      - "3000:3000"
+    command: npm start
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:22-alpine
+WORKDIR /usr/app
+COPY package.json .
+RUN npm install --quiet
+COPY . .
+EXPOSE 3000


### PR DESCRIPTION

This pull request includes changes to add Docker support for the frontend and database services, as well as providing a sample environment variable file. The most important changes include the addition of a Docker Compose configuration, a Dockerfile for the frontend service, and a sample environment variable for the SQL Server password.

Docker support:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R17): Added configuration for `frontend` and `mssql` services, including build instructions, ports, and environment variables.
* [`frontend/Dockerfile`](diffhunk://#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8R1-R6): Created a Dockerfile for the frontend service to set up the Node.js environment and expose port 3000.

Environment variables:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR1): Added a sample environment variable for the SQL Server password.